### PR TITLE
Delete users functionality for Admin

### DIFF
--- a/src/app/manage-users/manage-users.component.html
+++ b/src/app/manage-users/manage-users.component.html
@@ -82,9 +82,9 @@
               </ng-template>
             </mat-menu>             
   
-            <!-- <button class="deleteIcon" id="deletebutton" mat-icon-button >
+            <button class="deleteIcon" id="deletebutton" mat-icon-button >
               <mat-icon class="red" aria-label="Delete" (click)="openDialog(row.username)">delete</mat-icon>
-            </button> -->
+            </button>
           </mat-cell>
         </ng-container>
   
@@ -94,7 +94,7 @@
 
       <mat-toolbar>
         <mat-toolbar-row>
-          <!-- <button mat-raised-button  [disabled]="isselected()" id="buttonL" (click)="deleteSelectedUsers()" class="button_alignR">Delete Selected Users</button> -->
+          <button mat-raised-button  [disabled]="isselected()" id="buttonL" (click)="deleteSelectedUsers()" class="button_alignR">Delete Selected Users</button>
           <mat-paginator class="paginator" [pageSizeOptions]="[5, 10, 20]"></mat-paginator>
         </mat-toolbar-row>
       </mat-toolbar>

--- a/src/app/manage-users/manage-users.component.spec.ts
+++ b/src/app/manage-users/manage-users.component.spec.ts
@@ -52,7 +52,7 @@ describe('ManageUsersComponent', () => {
     expect(trigger.childElementCount).toBe(2);
     });
 
-  xit('DeleteSelectedUsers Button should invoke corresponding method', () => {
+  fit('DeleteSelectedUsers Button should invoke corresponding method', () => {
     const deleteUser = spyOn(component, 'deleteSelectedUsers');
     fixture.debugElement.query(By.css('#buttonL')).triggerEventHandler('click', null);
     expect(deleteUser).toHaveBeenCalled();

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -62,13 +62,12 @@ describe('UserService', () => {
       fit('deleteUsers should be called with the correct request parameters', inject([UserService, MockBackend],
         fakeAsync((userService: UserService, mockBackend: MockBackend) => {
           mockBackend.connections.subscribe((conn: MockConnection) => {
-            expect(conn.request.method).toBe(RequestMethod.Post);
-            expect(conn.request.url).toBe('/rest/adminDeleteUsers');
-            expect(conn.request.json().deleteUsers).toBe('vjv');
-            conn.mockRespond(new Response(new ResponseOptions({status: 201})));
+            expect(conn.request.method).toBe(RequestMethod.Delete);
+            expect(conn.request.url).toBe('/rest/adminDeleteUsers/vjv');
           });
           userService.deleteUsers('vjv').subscribe(() => {
          });
+         tick();
         })));
 
         fit('lockunlockUser should be called with the correct request parameters', inject([UserService, MockBackend],

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -28,10 +28,7 @@ export class UserService {
   }
 
   deleteUsers(user: string): Observable<any> {
-    const body = { 'deleteUsers': user };
-   const headers = new Headers({'Content-type': 'application/json'});
-   const options = new RequestOptions({headers: headers});
-   return this.http.post('/rest/adminDeleteUsers', body, options).pipe(
+   return this.http.delete('/rest/adminDeleteUsers/' + user).pipe(
    map(this.extractData),
    catchError(this.handleError));
   }


### PR DESCRIPTION
Delete users functionality for Admin

This PR contains the changes for 'Delete Users' functionality in 'Manage Users' page

**List of functionalities contained in this pull request**
Admin can delete a user by clicking on the delete icon in the 'Manage Users' page. List of Users can also be deleted by doing the appropriate selection in the checkbox and clicking on 'Delete Selected Users' button.

**List of the test cases**
user.service.spec.ts

can be tested with the PR #309 in the backend.

Below is screenshot of all passing test cases
![image](https://user-images.githubusercontent.com/37999970/51329905-b7957800-1a76-11e9-9105-de4ad2f74b3d.png)

