### PR TITLE
fixed bug on query by removing space between filter values

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -7,17 +7,19 @@
     No results found
   </p>
 
+  <p class="alert alert-warning" *ngIf="onerror">
+    An error occured
+  </p>
+
   <div class="box-padding">
     <form #form="ngForm">
       <div class="search_bar">
         <div class="row">
           <div class="column is-8">
-
             <input type="text" #query="ngModel" class="form-control" name="query" placeholder="" required [(ngModel)]="model.query" />
-
           </div>
           <div class="column is-4">
-            <button mat-raised-button type="submit" [disabled]="query.value === '' || query === undefined" (click)="search(model.query)"
+            <button mat-raised-button type="submit" [disabled]="query.value === '' || query === undefined" (click)="searchFilter(model.query)"
               class="btn-left-mrgn btn btn-success align-middle">
               Search
             </button>
@@ -82,16 +84,27 @@
       <input matInput (keyup)="applyDataSourceFilter($event.target.value)" placeholder="Filter" />
     </mat-form-field>
     <table #resultsTable mat-table matSort [dataSource]="resultDataSource" class="mat-elevation-z8">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Name.</th>
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
         <td mat-cell *matCellDef="let row">{{ row.id }}</td>
       </ng-container>
 
-
-      <ng-container matColumnDef="htmlUrl">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Origin</th>
-        <td mat-cell *matCellDef="let row">{{ row.metadata.source }}</td>
+      <ng-container matColumnDef="metric">
+        <th mat-header-cell *matHeaderCellDef>Metric</th>
+        <td mat-cell *matCellDef="let row">
+          <div *ngFor="let entry of row.metric | keyvalue">           
+          {{entry.key}} : {{entry.value}}
+          </div>
+        </td>
       </ng-container>
+
+      <ng-container matColumnDef="source">
+        <th mat-header-cell *matHeaderCellDef>Source</th>
+        <td mat-cell *matCellDef="let row">
+         {{row.source}}
+        </td>
+      </ng-container>
+
       <!-- Checkbox Column -->
       <ng-container matColumnDef="select">
         <th mat-header-cell *matHeaderCellDef>
@@ -132,14 +145,25 @@
 
     <div class="col-lg-12" *ngIf="getTotalItems() > 0" style="max-height:600px">
       <table mat-table [dataSource]="toAdd" class="mat-elevation-z8">
-        <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef>Name.</th>
+        <ng-container matColumnDef="id">
+          <th mat-header-cell *matHeaderCellDef>ID</th>
           <td mat-cell *matCellDef="let row">{{ row.id }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="htmlUrl">
-          <th mat-header-cell *matHeaderCellDef>Origin</th>
-          <td mat-cell *matCellDef="let row">{{ row.metadata.source }}</td>
+        <ng-container matColumnDef="metric">
+          <th mat-header-cell *matHeaderCellDef>Metric</th>
+          <td mat-cell *matCellDef="let row">
+            <div *ngFor="let entry of row.metric | keyvalue">           
+            {{entry.key}} : {{entry.value}}
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="source">
+          <th mat-header-cell *matHeaderCellDef>Source</th>
+          <td mat-cell *matCellDef="let row">
+           {{row.source}}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="select">

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -17,6 +17,8 @@ import { MatMenuModule, MatIconModule, MatPaginatorModule, MatDialogModule, MatB
 describe('SearchComponent', () => {
   let component: SearchComponent;
   let fixture: ComponentFixture<SearchComponent>;
+  let filter : string;
+  const selectedfilter : any = {filter: 'if_icmpgt (opcode:163)', value:'< 40', operand:'&&'}
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -35,6 +37,18 @@ describe('SearchComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+ 
+  fit("should return a parsed filter without operator if search textfield is empty", () => {
+   component.model.query = ''
+   filter = component.parseFilter(selectedfilter);
+   expect(filter).toEqual("[if_icmpgt (opcode:163)]<40") 
+  })
+
+  fit("should return a parsed filter with operator if a filter has been previously applied to the search textfield", () => {
+   component.model.query = '[if_icmpgt (opcode:163)]>34'
+   filter = component.parseFilter(selectedfilter);
+   expect(filter).toEqual("[if_icmpgt (opcode:163)]>34&&[if_icmpgt (opcode:163)]<40") 
+  })
 
   fit('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -30,6 +30,7 @@ import { Promise } from 'q';
 export class SearchComponent implements OnInit {
   model = new Search('');
   loading: boolean;
+  onerror : boolean = false;
   results = [];
   resultDataSource = new MatTableDataSource<any>(this.results);
   toAdd = [];
@@ -224,13 +225,15 @@ export class SearchComponent implements OnInit {
     { field: 'htmlUrl', header: 'Origin' }
   ]; */
     this.searchColumns = [
-      'name',
-      'htmlUrl',
+      'id',
+      'metric',
+      'source',
       'select'
     ];
     this.addColumns = [
-      'name',
-      'htmlUrl',
+      'id',
+      'metric',
+      'source',
       'select'
     ];
     this.filterColumns = ['filter', 'value', 'operand', 'action'];
@@ -267,18 +270,33 @@ export class SearchComponent implements OnInit {
 
   applyFilter(row: any) {
     this.model.query += this.parseFilter(row);
-    console.log(this.parseFilter(row))
     row.value = '';
   }
 
 
   searchFilter(searchQuery: string) {
     this.loading = true;
+    this.onerror = false;
     this.resultDataSource.data = [];
-    this.service.getFiltersSearch(searchQuery).subscribe(response => {
-      console.log(response.json());
+    this.service.getFiltersSearch(searchQuery).subscribe(resp => {
+      let response = JSON.parse(resp.json());
+       let data = [...response];
+      this.resultDataSource.data = data.map(result =>{
+        return {
+          id: result.id,
+          source: result.metadata.source,
+          metric: result.metricResults,
+          singleSelection : false
+        }
+      })
+    setTimeout(()=>  console.log(this.resultDataSource.data));
+    setTimeout(() => (this.resultDataSource.paginator = this.resultPaginator));
+    this.loading = false;
+    this.searched = true;
+    },
+    error => {
+      this.onerror = true;
       this.loading = false;
-      this.searched = true;
     });
   }
 

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -267,15 +267,29 @@ export class SearchComponent implements OnInit {
 
   applyFilter(row: any) {
     this.model.query += this.parseFilter(row);
+    console.log(this.parseFilter(row))
     row.value = '';
   }
 
-  parseFilter(filter: any) {
+
+  searchFilter(searchQuery: string) {
+    this.loading = true;
+    this.resultDataSource.data = [];
+    this.service.getFiltersSearch(searchQuery).subscribe(response => {
+      console.log(response.json());
+      this.loading = false;
+      this.searched = true;
+    });
+  }
+
+  parseFilter(row: any) {
     let value = this.model.query;
+    //remove spaces between filter values
+    row.value = row.value.split(" ").join("")
     if (value.trim().length < 1) {
-      return `[${filter.filter}]${filter.value}`;
-    }
-    return `${filter.operand}[${filter.filter}]${filter.value}`;
+      return `[${row.filter}]${row.value}`;
+    } 
+    return `${row.operand}[${row.filter}]${row.value}`;
   }
 
   applyDataSourceFilter(filterValue: string) {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -25,7 +25,6 @@ export class SearchService {
 
   getFiltersSearch(query: string) {
     let body = JSON.stringify({query});
-    console.log('Json format '  + body);
     return this.http.post('/rest/searchquery', body);
   }
 }


### PR DESCRIPTION
---
name: Removing additional spaces in query filter value
about: This pull request handles removing spaces in filters when generating filters for your search
---

**Is your pull request related to an issue? Please describe.**
This pull request is related to issue  #292. Additional spaces in queries throw an error on the server, these spaces could result when entering filter values for your search filters, a user might enter values containing spaces for example " > 1" instead of ">1". 

**List of functionalities contained in this pull request**
A function that parses user filter in the right form and removing spaces in between values

