### PR TITLE
Remove space in query filter value

### DIFF
--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -17,6 +17,8 @@ import { MatMenuModule, MatIconModule, MatPaginatorModule, MatDialogModule, MatB
 describe('SearchComponent', () => {
   let component: SearchComponent;
   let fixture: ComponentFixture<SearchComponent>;
+  let filter: string;
+  const selectedfilter: any = {filter: 'if_icmpgt (opcode:163)', value: '< 40', operand: '&&'};
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -35,6 +37,17 @@ describe('SearchComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+
+  fit('should return a parsed filter without operator if search textfield is empty', () => {
+    component.model.query = '';
+    filter = component.parseFilter(selectedfilter);
+    expect(filter).toEqual('[if_icmpgt (opcode:163)]<40');
+  });
+  fit('should return a parsed filter with operator if a filter has been previously applied to the search textfield', () => {
+    component.model.query = '[if_icmpgt (opcode:163)]>34';
+    filter = component.parseFilter(selectedfilter);
+    expect(filter).toEqual('&&[if_icmpgt (opcode:163)]<40');
+   });
 
   fit('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -272,8 +272,8 @@ export class SearchComponent implements OnInit {
 
   parseFilter(row: any) {
     let value = this.model.query;
-    //remove spaces between filter values
-    row.value = row.value.split(" ").join("")
+    // remove spaces between filter values
+    row.value = row.value.split(' ').join('');
     if (value.trim().length < 1) {
       return `[${row.filter}]${row.value}`;
     }

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -270,12 +270,14 @@ export class SearchComponent implements OnInit {
     row.value = '';
   }
 
-  parseFilter(filter: any) {
+  parseFilter(row: any) {
     let value = this.model.query;
+    //remove spaces between filter values
+    row.value = row.value.split(" ").join("")
     if (value.trim().length < 1) {
-      return `[${filter.filter}]${filter.value}`;
+      return `[${row.filter}]${row.value}`;
     }
-    return `${filter.operand}[${filter.filter}]${filter.value}`;
+    return `${row.operand}[${row.filter}]${row.value}`;
   }
 
   applyDataSourceFilter(filterValue: string) {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -25,7 +25,6 @@ export class SearchService {
 
   getFiltersSearch(query: string) {
     let body = JSON.stringify({query});
-    console.log('Json format '  + body);
     return this.http.post('/rest/searchquery', body);
   }
 }


### PR DESCRIPTION
---
name: Removing additional space in query filter value 
about: This pull request handles removing spaces in filters when generating filters for your search
---

**Is your pull request related to an issue? Please describe.**
This pull request is related to issue #292. Additional spaces in queries throw an error on the server, these spaces could result when entering filter values for your search filters, a user might enter values containing spaces for example " > 1" instead of ">1". 

**List of functionalities contained in this pull request**
A function that parses user filter in the right form and removing spaces in between values

**List of the test cases**
A test to check if filter is well parsed if search text field is empty
A test to check if filter is well parsed if filter has been previously applied to search text field 
